### PR TITLE
refactor: extraer tipo inline de properties en IconComponent a una interfaz dedicada/56

### DIFF
--- a/src/app/shared/components/icons/icons.component.ts
+++ b/src/app/shared/components/icons/icons.component.ts
@@ -1,6 +1,7 @@
 import { NgClass, NgSwitch, NgSwitchCase } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { Icon } from 'src/app/shared/interfaces/icons.interface';
+import { IconProperties } from 'src/app/shared/interfaces/icon-properties.interface';
 
 @Component({
   selector: 'app-icon',
@@ -11,7 +12,7 @@ import { Icon } from 'src/app/shared/interfaces/icons.interface';
 })
 export class IconComponent {
   @Input() iconName: Icon = 'system';
-  @Input() properties: { id: string; class: string } = { id: '', class: '' };
+  @Input() properties: IconProperties = { id: '', class: '' };
 
   constructor() {}
 }

--- a/src/app/shared/interfaces/icon-properties.interface.ts
+++ b/src/app/shared/interfaces/icon-properties.interface.ts
@@ -1,0 +1,4 @@
+export interface IconProperties {
+  id: string;
+  class: string;
+}


### PR DESCRIPTION
Se extrajo el tipo de propiedades de IconComponent que estaba definido inline a una nueva interfaz dedicada
